### PR TITLE
Fixes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+ignore:
+  - "src/main/java/edu/fiuba/algo3/controlador"
+  - "src/main/java/edu/fiuba/algo3/vista"
+  - "src/main/java/edu/fiuba/algo3/App.java"
+  - "src/main/java/edu/fiuba/algo3/Main.java"
+  - "src/main/java/edu/fiuba/algo3/SystemInfo.java"

--- a/docs/Desarrollo.md
+++ b/docs/Desarrollo.md
@@ -9,9 +9,9 @@ Existen distintas maneras de configurar el ambiente de desarrollo:
 - [Nativo](./Nativo.md)
 - [Docker](./Docker.md)
 
-### Diagramas
+## Diagramas
 
-[Plantuml](https://plantuml.com/) soporta un mecanísmo que les facilitará la generación y posterior mantenimiento de los diagramas de clase, secuencia, estado y paquetes. Para mayor información referir [guía de PlantUML](./docs/PLANTUML.md)
+[Plantuml](https://plantuml.com/) soporta un mecanísmo que les facilitará la generación y posterior mantenimiento de los diagramas de clase, secuencia, estado y paquetes. Para mayor información referir [guía de PlantUML](./PlantUML.md)
 
 ## Empaquetado
 

--- a/docs/PlantUML.md
+++ b/docs/PlantUML.md
@@ -22,7 +22,7 @@ Este script inspecciona la carpeta `diagrams/`.
 Forma de ejecución:
 
 ```bash
-scripts/render_diagrams.sh 
+$ scripts/render_diagrams.sh 
 ```
 
 **Nota 1:** 
@@ -58,7 +58,7 @@ Existen múltiples plugins para interpretar estos archivos
         
 Esto les permitiría definir sus clases (una única vez) y utilizarlas en la definición de sus relaciones. 
 
-Aquí pueden econtrar un ejemplo [ejemplo](../diagrams/)
+Aquí pueden encontrar un ejemplo [ejemplo](../diagrams/)
 
 **Sugerencia:**
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.6</version>
                 <configuration>
-                    <mainClass>${main-class}</mainClass>
+                    <mainClass>edu.fiuba.algo3/${main-class}</mainClass>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Este pr realiza un par de fixes generales:
- Actualiza la doc corrigiendo un error de tipeo, un link roto y estilos.
- Evita un warning al correr `mvn javajx:run`
- Agrega un archivo `codecov.yml` para ignorar clases que no tengan que ver con el modelo al reportar la cobertura.