### PR TITLE
Update codecov plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Run test suite
         run: docker-compose -f docker/docker-compose.yaml exec -T app bash scripts/build.sh
       - name: Upload coverage report
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v2
 
   package:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Este pr actualiza la forma de subir el reporte de cobertura a codecov dado que el bash uploader está siendo deprecado https://docs.codecov.com/docs/about-the-codecov-bash-uploader.